### PR TITLE
Strip v from tagname if present

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Set version from tag
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          mvn versions:set -DnewVersion=${TAG}
+          VERSION=${TAG#v} # Strip the 'v' if it exists
+          mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${VERSION}
 
       - name: Build with Maven
         run: mvn --batch-mode  --no-transfer-progress clean package


### PR DESCRIPTION
If a release tag begins with v like v1.0.0 it will be stripped. Jar package files will then only use the 1.0.0 in the naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the release process to accurately format version identifiers and streamline the release workflow, ensuring a more reliable and efficient deployment cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->