### PR TITLE
add release-drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🐛 Bug Fixes'
+    collapse-after: 4
+    labels:
+      - 'bug'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+exclude-labels:
+  - 'skip-changelog'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: minor
+template: |
+  ### **Breeze** 💨
+  **Release:** v.$RESOLVED_VERSION
+  
+  A slight breeze passes by, taking with it the smell of change!
+  
+  ## What's Changed
+
+  $CHANGES

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,18 @@
+name: release-draft.yml
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Merging this PR adds the release-drafter workflow.

The workflow is **dependent on labels being set on PRs**. The following labels are used:

* bug: group your changes with other bugs (these are patches in semantic versioning)
* patch: Increments the release by 0.0.1
* minor: Increments the release by 0.1.0
* major: Increments the release by 1.0.0

> **NOTE**: If there is already an existing draft. The version number isn't bumped until the draft is fully released. It also takes the largest versioning bump (eg. major > minor > patch) if a PR is labeled with both. Always make sure you have at least version labeled your PR before merging!

## Issues Closed
This PR closes the following issues:

Closes #33: Add release drafter