### PR TITLE
Implemented sliding2 Array Operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,27 @@
             <artifactId>assertj-core</artifactId>
             <version>3.27.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.27.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.0.0-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+            <version>0.10.4</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/org/fungover/breeze/util/Arrays.java
+++ b/src/main/java/org/fungover/breeze/util/Arrays.java
@@ -1,0 +1,32 @@
+package org.fungover.breeze.util;
+
+import com.google.common.collect.ImmutableList;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Arrays {
+
+    // Generic method to create a list of sliding pairs from an array
+    public static <T> ImmutableList<Tuple2<T, T>> sliding2(T[] array) {
+
+        // Check if the array is null or has fewer than 2 elements (not enough to form pairs)
+        if (array == null || array.length < 2) {
+            return ImmutableList.of(); // Return an empty list if invalid input
+        }
+
+        // List to store pairs of adjacent elements
+        List<Tuple2<T, T>> pairs = new ArrayList<>();
+
+        // Loop through the array and create pairs of adjacent elements
+        for (int i = 0; i < array.length - 1; i++) {
+
+            // Create a pair (Tuple2) for the current element and the next element
+            pairs.add(Tuple.of(array[i], array[i + 1]));
+        }
+
+        // Return the list of pairs wrapped in an immutable list
+        return ImmutableList.copyOf(pairs);
+    }
+}

--- a/src/test/java/org/fungover/breeze/util/ArraysTest.java
+++ b/src/test/java/org/fungover/breeze/util/ArraysTest.java
@@ -1,0 +1,82 @@
+package org.fungover.breeze.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import com.google.common.collect.ImmutableList;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import org.junit.jupiter.api.Test;
+
+public class ArraysTest {
+
+    @Test
+    void testNormalArray() {
+        Integer[] arr = {1, 2, 3, 4};
+        ImmutableList<Tuple2<Integer, Integer>> result = Arrays.sliding2(arr);
+
+        assertEquals(3, result.size());
+        assertEquals(Tuple.of(1, 2), result.get(0));  // Fixed
+        assertEquals(Tuple.of(2, 3), result.get(1));  // Fixed
+        assertEquals(Tuple.of(3, 4), result.get(2));  // Fixed
+    }
+
+    @Test
+    void testTwoElementArray() {
+        String[] arr = {"A", "B"};
+        ImmutableList<Tuple2<String, String>> result = Arrays.sliding2(arr);
+
+        assertEquals(1, result.size());
+        assertEquals(Tuple.of("A", "B"), result.get(0));
+    }
+
+    @Test
+    void testSingleElementArray() {
+        Integer[] arr = {42};
+        assertTrue(Arrays.sliding2(arr).isEmpty());
+    }
+
+    @Test
+    void testEmptyArray() {
+        Integer[] arr = {};
+        assertTrue(Arrays.sliding2(arr).isEmpty());
+    }
+
+    @Test
+    void testArrayWithNulls() {
+        Integer[] arr = {1, null, 3};
+        ImmutableList<Tuple2<Integer, Integer>> result = Arrays.sliding2(arr);
+
+        assertEquals(2, result.size());
+        assertEquals(Tuple.of(1, null), result.get(0));
+        assertEquals(Tuple.of(null, 3), result.get(1));
+    }
+
+    @Test
+    void testLargeArrayPerformance() {
+        int size = 1_000_000;  // 1 million elements
+        Integer[] largeArray = new Integer[size];
+
+        // Fill array with numbers 0 to 999,999
+        for (int i = 0; i < size; i++) {
+            largeArray[i] = i;
+        }
+
+        long startTime = System.nanoTime();  // Start timing
+
+        ImmutableList<Tuple2<Integer, Integer>> result = Arrays.sliding2(largeArray);
+
+        long endTime = System.nanoTime();  // End timing
+        long durationMs = (endTime - startTime) / 1_000_000; // Convert to milliseconds
+
+        // Check number of pairs (N-1)
+        assertEquals(size - 1, result.size());
+
+        // Check a few pairs to ensure correctness
+        assertEquals(Tuple.of(0, 1), result.get(0));
+        assertEquals(Tuple.of(999998, 999999), result.get(size - 2));
+
+        System.out.println("Large array test completed in " + durationMs + " ms");
+
+        // Optional: Assert performance (e.g., should complete in < 500ms)
+        assertTrue(durationMs < 500, "Performance issue: took too long!");
+    }
+}


### PR DESCRIPTION
PR for Issue: #20 
Merging this PR adds the sliding2 array operation. Key features and improvements implemented in this PR include:

- Core Functionality:
   - Introduced the sliding2 method to create pairs of adjacent elements from an input array
   - Uses Vavr's Tuple2 to represent pairs and Guava's ImmutableList for an immutable, thread-safe return type
    - Handles edge cases like null or arrays with fewer than 2 elements by returning an empty list