### PR TITLE
Javadoc fixes

### DIFF
--- a/src/main/java/org/fungover/breeze/Procrastinator.java
+++ b/src/main/java/org/fungover/breeze/Procrastinator.java
@@ -6,6 +6,7 @@ package org.fungover.breeze;
  * @deprecated As of release 0.2.0. Will be removed in a future release
  */
 @Deprecated(since="0.2.0", forRemoval = true)
+@SuppressWarnings("squid:S1133")
 public class Procrastinator {
 
     private Procrastinator() {}

--- a/src/main/java/org/fungover/breeze/Procrastinator.java
+++ b/src/main/java/org/fungover/breeze/Procrastinator.java
@@ -6,7 +6,6 @@ package org.fungover.breeze;
  * @deprecated As of release 0.2.0. Will be removed in a future release
  */
 @Deprecated(since="0.2.0", forRemoval = true)
-@SuppressWarnings("squid:S1133")
 public class Procrastinator {
 
     private Procrastinator() {}

--- a/src/main/java/org/fungover/breeze/Procrastinator.java
+++ b/src/main/java/org/fungover/breeze/Procrastinator.java
@@ -2,8 +2,14 @@ package org.fungover.breeze;
 
 /**
  * A utility class for when you need to do absolutely nothing, but in a professional way.
+ *
+ * @deprecated As of release 0.2.0. Will be removed in a future release
  */
+@Deprecated(since="0.2.0", forRemoval = true)
 public class Procrastinator {
+
+    private Procrastinator() {}
+
     /**
      * Does absolutely nothing, but promises to do it tomorrow.
      *

--- a/src/main/java/org/fungover/breeze/funclib/control/Either.java
+++ b/src/main/java/org/fungover/breeze/funclib/control/Either.java
@@ -150,6 +150,9 @@ public sealed interface Either<L extends Serializable, R extends Serializable> e
    * @param <R> The type of the right value (unused in this case)
    */
   final class Left<L extends Serializable, R extends Serializable> implements Either<L, R> {
+    /**
+     * It represents the value inside the {@code Left}'s instance
+     */
     private final L value;
 
     /**
@@ -313,6 +316,9 @@ public sealed interface Either<L extends Serializable, R extends Serializable> e
    * @param <R> The type of the right value (typically a success type)
    */
   final class Right<L extends Serializable, R extends Serializable> implements Either<L, R> {
+    /**
+     * It represents the value inside the {@code Right}'s instance
+     */
     private final R value;
 
     /**

--- a/src/main/java/org/fungover/breeze/util/Arrays.java
+++ b/src/main/java/org/fungover/breeze/util/Arrays.java
@@ -7,6 +7,9 @@ import java.lang.reflect.Array;
  */
 public class Arrays {
 
+    /**
+     * Don't let anyone instantiate this class
+     */
     private Arrays() {}
 
     /**

--- a/src/main/java/org/fungover/breeze/util/Arrays.java
+++ b/src/main/java/org/fungover/breeze/util/Arrays.java
@@ -2,7 +2,12 @@ package org.fungover.breeze.util;
 
 import java.lang.reflect.Array;
 
+/**
+ * A class containing static Array utility functions.
+ */
 public class Arrays {
+
+    private Arrays() {}
 
     /**
      * Transposes a 2D array, converting rows into columns and vice versa.

--- a/src/main/java/org/fungover/breeze/util/Strings.java
+++ b/src/main/java/org/fungover/breeze/util/Strings.java
@@ -6,6 +6,8 @@ package org.fungover.breeze.util;
 
 public class Strings {
 
+    private Strings() {}
+
     /**
      * Capitalizes the first letter of the given string.
      *

--- a/src/main/java/org/fungover/breeze/util/Strings.java
+++ b/src/main/java/org/fungover/breeze/util/Strings.java
@@ -6,6 +6,9 @@ package org.fungover.breeze.util;
 
 public class Strings {
 
+    /**
+     * Don't let anyone instantiate this class
+     */
     private Strings() {}
 
     /**

--- a/src/test/java/org/fungover/breeze/util/ArraysTest.java
+++ b/src/test/java/org/fungover/breeze/util/ArraysTest.java
@@ -1,6 +1,5 @@
-package org.fungover.breeze;
+package org.fungover.breeze.util;
 
-import org.fungover.breeze.util.Arrays;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
This pull request fixes all Javadoc errors that currently exist.

This PR closes these issues:
Closes #45: Fix javadoc build warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - A legacy scheduling utility is now deprecated and scheduled for removal in a future release.
  - Several utility modules have been refined to prevent direct instantiation, reinforcing their intended static usage.

- **Documentation**
  - Enhanced inline guidance clarifies the role and content of value containers within the library.
  - Class-level documentation added to utility classes to describe their purpose.

- **Tests**
  - Test organization was updated to streamline alignment with the revised utility structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->