### PR TITLE
95 add edge case handling for 1x1 arrays new

### DIFF
--- a/src/main/java/org/fungover/breeze/util/Arrays.java
+++ b/src/main/java/org/fungover/breeze/util/Arrays.java
@@ -338,6 +338,11 @@ public class Arrays {
         int rows = array.length;
         int cols = array[0].length;
 
+        // Handle the 1×1 edge case
+        if (rows == 1 && cols == 1) {
+            return array; // No need to transpose a single-element array
+        }
+
         // Validate that all rows have the same length
         for (T[] row : array) {
             if (row == null) {

--- a/src/test/java/org/fungover/breeze/util/ArraysTest.java
+++ b/src/test/java/org/fungover/breeze/util/ArraysTest.java
@@ -625,6 +625,15 @@ class ArraysTest {
     }
 
     @Test
+    void testTranspose_1x1Array() {
+        Integer[][] input = {{42}};
+        Integer[][] result = Arrays.transpose(input);
+
+        // Check if the same instance is returned (optimization)
+        assertSame(input, result, "1×1 array transposition should return the same instance");
+    }
+
+    @Test
     @DisplayName("Preserve Type Information")
     void preservedTypeInformation() {
         String[][] input = {


### PR DESCRIPTION
A 1×1 array (a single-element array) does not change when transposed. However, in the current implementation, the method still goes through the full transposition process, which is unnecessary.

Why should we handle this case separately?

Efficiency: There’s no need to allocate memory or loop through elements if the array is already in its final form.
Avoids Unnecessary Computation: The method currently creates a new array and assigns values, even though nothing changes.
Prevents Potential Edge-Case Bugs: Explicitly handling it ensures that no unnecessary operations are performed.

Pull #95 into main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved array transposition to handle single-element (1×1) arrays efficiently, by returning the original array without unnecessary processing.
  
- **Tests**
  - Added a dedicated test to verify that transposing a 1×1 array maintains the expected behavior.

These updates enhance performance and ensure robust handling of edge-case input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->