### PR TITLE
Add toList Method to FQueue

### DIFF
--- a/src/main/java/org/fungover/breeze/collection/FQueue.java
+++ b/src/main/java/org/fungover/breeze/collection/FQueue.java
@@ -116,4 +116,20 @@ public class FQueue<T> {
         Collections.reverse(reversedBack);
         return new FQueue<>(reversedBack, reversedFront);
     }
+
+    /**
+     * Returns an immutable list containing all elements in the queue in FIFO order.
+     *
+     * @return an immutable list of the queue's elements
+     */
+    public List<T> toList(){
+        List<T> reveresedBack = new ArrayList<>(back);
+        Collections.reverse(reveresedBack);
+
+        List<T> combined = Stream.concat(front.stream(), reveresedBack.stream())
+                .collect(Collectors.toList());
+
+        return Collections.unmodifiableList(combined);
+
+    }
 }

--- a/src/test/java/org/fungover/breeze/collection/FQueueTest.java
+++ b/src/test/java/org/fungover/breeze/collection/FQueueTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class FQueueTest {
@@ -74,5 +75,15 @@ class FQueueTest {
         
         assertTrue(reversed.isEmpty());
         assertEquals(0, reversed.size());
+    }
+
+    @Test
+    void testToListReturnsImmutableListOfQueue(){
+        FQueue<Integer> queue = FQueue.empty();
+        queue = queue.enqueue(10);
+        queue = queue.enqueue(20);
+        queue = queue.enqueue(30);
+
+        assertThat(queue.toList()).containsExactly(10,20,30);
     }
 }


### PR DESCRIPTION
Add Test for toList method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to convert a queue’s elements into an immutable list in FIFO order.

- **Tests**
  - Added robust tests to verify that the immutable list accurately represents the queue contents and remains unmodifiable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->