### PR TITLE
117 implement tuple3 and tuple4 classes

### DIFF
--- a/src/main/java/org/fungover/breeze/control/Tuple3.java
+++ b/src/main/java/org/fungover/breeze/control/Tuple3.java
@@ -134,7 +134,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
      * @param function the function that should be applied on this objects first element
      * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
      * @return a new Tuple3 with R first, T2 second and T3 third as values.
-     * @throws IllegalArgumentException if result of the function (R) is null
+     * @throws IllegalArgumentException if R result of the function is null
      */
     public <R extends Comparable<? super R> & Serializable> Tuple3<R, T2, T3> map1(Function<T1, R> function) {
 
@@ -151,7 +151,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
      * @param function the function that should be applied on this objects second element
      * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
      * @return a new Tuple3 with T1 first, R second and T3 third as values.
-     * @throws IllegalArgumentException if result of the function (R) is null
+     * @throws IllegalArgumentException if R result of the function is null
      */
     public <R extends Comparable<? super R> & Serializable> Tuple3<T1, R, T3> map2(Function<T2, R> function) {
 
@@ -168,7 +168,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
      * @param function the function that should be applied on this objects third element
      * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
      * @return a new Tuple3 with T1 first, T2 second and R third as values.
-     * @throws IllegalArgumentException if result of the function (R) is null
+     * @throws IllegalArgumentException if R result of the function is null
      */
     public <R extends Comparable<? super R> & Serializable> Tuple3<T1, T2, R> map3(Function<T3, R> function) {
 
@@ -199,6 +199,70 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
         R3 thirdFunctionResult = checkForNullFunctionResult(function3.apply(third));
 
         return Tuple3.of(firstFunctionResult, secondFunctionResult, thirdFunctionResult);
+    }
+
+    /**
+     * Appends the specified element as the last element of the tuple, which converts it into a larger Tuple size.
+     * Returns a new Tuple4 object with:
+     * this.first as first, this.second as second, this.third as third and E element as fourth.
+     *
+     * @param element the element that should be appended
+     * @param <E>     class type of the element to append where class must implement serializable and class (or superclass) must implement comparable
+     * @return a new Tuple4 object
+     * @throws IllegalArgumentException if E element is null
+     */
+    public <E extends Comparable<? super E> & Serializable> Tuple4<T1, T2, T3, E> append(E element) {
+        if (element == null) {
+            throw new IllegalArgumentException("Cannot append a null element");
+        }
+        return Tuple4.of(first, second, third, element);
+    }
+
+    /**
+     * Prepends the specified element as the first element of the tuple which converts it into a larger Tuple size.
+     * Returns a new Tuple4 object with:
+     * E element as first, this.first as second, this.second as third and this.third as fourth.
+     *
+     * @param element the element that should be appended
+     * @param <E>     class type of the element to prepend where class must implement serializable and class (or superclass) must implement comparable
+     * @return a new Tuple4 object
+     * @throws IllegalArgumentException if E element is null
+     */
+    public <E extends Comparable<? super E> & Serializable> Tuple4<E, T1, T2, T3> prepend(E element) {
+        if (element == null) {
+            throw new IllegalArgumentException("Cannot prepend a null element");
+        }
+        return Tuple4.of(element, first, second, third);
+    }
+
+    /**
+     * Drops the first element and returns a new Tuple2 with:
+     * this.second as first and this.third as second.
+     *
+     * @return new Tuple2 object
+     */
+    public Tuple2<T2, T3> dropFirst() {
+        return Tuple2.of(second, third);
+    }
+
+    /**
+     * Drops the second element and returns a new Tuple2 with:
+     * this.first as first and this.third as second.
+     *
+     * @return new Tuple2 object
+     */
+    public Tuple2<T1, T3> dropSecond() {
+        return Tuple2.of(first, third);
+    }
+
+    /**
+     * Drops the third element and returns a new Tuple2 with:
+     * this.first as first and this.second as second.
+     *
+     * @return new Tuple2 object
+     */
+    public Tuple2<T1, T2> dropThird() {
+        return Tuple2.of(first, second);
     }
 
     /**

--- a/src/main/java/org/fungover/breeze/control/Tuple3.java
+++ b/src/main/java/org/fungover/breeze/control/Tuple3.java
@@ -15,7 +15,6 @@ import java.util.function.Function;
  * All fields are set as private and final.
  * Factory method of() to initialize new instance.
  * Methods that produce a change in any element returns a new instance.
- * Any call to methods in this class with a null object will result in a NullPointerException.
  *
  * @param <T1> class type of first element where class must implement serializable and class (or superclass) must implement comparable.
  * @param <T2> class type of second element where class must implement serializable and class (or superclass) must implement comparable.
@@ -120,7 +119,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
     /**
      * Returns the third element of this tuple
      *
-     * @return second
+     * @return third
      */
     public T3 third() {
         return third;

--- a/src/main/java/org/fungover/breeze/control/Tuple3.java
+++ b/src/main/java/org/fungover/breeze/control/Tuple3.java
@@ -1,0 +1,301 @@
+package org.fungover.breeze.control;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Final class that defines a comparable Tuple with an element size of 3.
+ * The class implements Comparable and Serializable.
+ * A tuple is useful for storing objects of equal or different class types.
+ * <p>
+ * Initialize: Tuple3.of(1, "two", 3.0);
+ * <p>
+ * All fields are set as private and final.
+ * Factory method of() to initialize new instance.
+ * Methods that produce a change in any element returns a new instance.
+ * Any call to methods in this class with a null object will result in a NullPointerException.
+ *
+ * @param <T1> class type of first element where class must implement serializable and class (or superclass) must implement comparable.
+ * @param <T2> class type of second element where class must implement serializable and class (or superclass) must implement comparable.
+ * @param <T3> class type of third element where class must implement serializable and class (or superclass) must implement comparable.
+ */
+public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable> implements Serializable, Comparable<Tuple3<T1, T2, T3>> {
+
+    /**
+     * This value represents the first element of this object.
+     */
+    private final T1 first;
+
+    /**
+     * This value represents the second element of this object.
+     */
+    private final T2 second;
+
+    /**
+     * This value represents the third element of this object.
+     */
+    private final T3 third;
+
+    /**
+     * Private constructor that initialize a new Tuple3 object.
+     *
+     * @param first  first element of the tuple
+     * @param second second element of the tuple
+     * @param third third element of the tuple
+     */
+    private Tuple3(T1 first, T2 second, T3 third) {
+        this.first = first;
+        this.second = second;
+        this.third = third;
+    }
+
+    /**
+     * Constructs a Tuple3 with 3 elements.
+     *
+     * @param first  first not null element in the tuple
+     * @param second second not null element in the tuple
+     * @param third third not null element in the tuple
+     * @param <T1>   class type of first element where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <T2>   class type of second element where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <T3>   class type of third element where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple3 with 3 elements
+     * @throws IllegalArgumentException if any argument is null
+     */
+    public static <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+    Tuple3<T1, T2, T3> of(T1 first, T2 second, T3 third) {
+
+        if (first == null || second == null || third == null) {
+            throw new IllegalArgumentException("Argument cannot be null");
+        }
+        return new Tuple3<>(first, second, third);
+    }
+
+    /**
+     * Returns the first element of this tuple
+     * @return first
+     */
+    public T1 _1() {
+        return first;
+    }
+
+    /**
+     * Returns the second element of this tuple
+     * @return second
+     */
+    public T2 _2() {
+        return second;
+    }
+
+    /**
+     * Returns the third element of this tuple
+     * @return third
+     */
+    public T3 _3() {
+        return third;
+    }
+
+    /**
+     * Returns the first element of this tuple
+     * @return first
+     */
+    public T1 first() {
+        return first;
+    }
+
+    /**
+     * Returns the second element of this tuple
+     * @return second
+     */
+    public T2 second() {
+        return second;
+    }
+
+    /**
+     * Returns the third element of this tuple
+     * @return second
+     */
+    public T3 third() {
+        return third;
+    }
+
+    /**
+     * Applies specified function to the first element of this tuple object and returns
+     * a new Tuple3 object with the result of the function as its first element, this.second as its second element and
+     * this.third as its third element.
+     *
+     * @param function the function that should be applied on this objects first element
+     * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple3 with R first, T2 second and T3 third as values.
+     * @throws IllegalArgumentException if result of the function (R) is null
+     */
+    public <R extends Comparable<? super R> & Serializable> Tuple3<R, T2, T3> map1(Function<T1, R> function) {
+
+        R functionResult = checkForNullFunctionResult(function.apply(first));
+
+        return Tuple3.of(functionResult, second, third);
+    }
+
+    /**
+     * Applies the specified function to the second element of this tuple object and returns
+     * a new Tuple3 object with this.first as its first element, the result of the function as its second element and
+     * this.third as its third element.
+     *
+     * @param function the function that should be applied on this objects second element
+     * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple3 with T1 first, R second and T3 third as values.
+     * @throws IllegalArgumentException if result of the function (R) is null
+     */
+    public <R extends Comparable<? super R> & Serializable> Tuple3<T1, R, T3> map2(Function<T2, R> function) {
+
+        R functionResult = checkForNullFunctionResult(function.apply(second));
+
+        return Tuple3.of(first, functionResult, third);
+    }
+
+    /**
+     * Applies the specified function to the third element of this tuple object and returns
+     * a new Tuple3 object with this.first as its first element, this.second as its second element and
+     * the result of the function as its third element.
+     *
+     * @param function the function that should be applied on this objects third element
+     * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple3 with T1 first, T2 second and R third as values.
+     * @throws IllegalArgumentException if result of the function (R) is null
+     */
+    public <R extends Comparable<? super R> & Serializable> Tuple3<T1, T2, R> map3(Function<T3, R> function) {
+
+        R functionResult = checkForNullFunctionResult(function.apply(third));
+
+        return Tuple3.of(first, second, functionResult);
+    }
+
+
+    /**
+     * Applies the specified functions to this tuple objects elements and returns
+     * a new Tuple3 object with the results of the functions its elements.
+     *
+     * @param function1 the function that should be applied on this objects first element
+     * @param function2 the function that should be applied on this objects second element
+     * @param function3 the function that should be applied on this objects third element
+     * @param <R1>      class type of the element that results from function1 where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <R2>      class type of the element that results from function2 where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <R3>      class type of the element that results from function3 where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple3 with R1 first, R2 second and R3 third as values.
+     * @throws IllegalArgumentException if result of any function (R1, R2 or R3) is null
+     */
+    public <R1 extends Comparable<? super R1> & Serializable, R2 extends Comparable<? super R2> & Serializable, R3 extends Comparable<? super R3> & Serializable>
+    Tuple3<R1, R2, R3> mapAll(Function<T1, R1> function1, Function<T2, R2> function2, Function<T3, R3> function3) {
+
+        R1 firstFunctionResult = checkForNullFunctionResult(function1.apply(first));
+        R2 secondFunctionResult = checkForNullFunctionResult(function2.apply(second));
+        R3 thirdFunctionResult = checkForNullFunctionResult(function3.apply(third));
+
+        return Tuple3.of(firstFunctionResult, secondFunctionResult, thirdFunctionResult);
+    }
+
+    /**
+     * Converts this tuple objects elements into an Object[] array.
+     * The order of the elements in this object will transpose to the Object[] array order,
+     * meaning that this.first will be at index 0 of the array, this.second will be at index 1,
+     * and so forth if this object contains more elements.
+     *
+     * @return a new Object[] array containing the elements of this tuple object.
+     */
+    public Object[] toArray() {
+        return new Object[]{first, second, third};
+    }
+
+    /**
+     * Converts this tuple objects elements into an immutable List of type Object.
+     * The order of the elements in this object will transpose to list order,
+     * meaning that this.first will be at index 0 of the list, this.second will be at index 1,
+     * and so forth if this object contains more elements.
+     *
+     * @return an immutable List of type Object containing the elements of this tuple object.
+     */
+    public List<Object> toList() {
+        return List.of(first, second, third);
+    }
+
+    /**
+     * Compares this object with the specified object for order.
+     * The order of one Tuple compared with another Tuple is dependent on
+     * their elements order where the first element is prioritized,
+     * and the rest are sequentially following.
+     * This means that element T1 first is initially compared between the Tuple objects and
+     * only if they are equal will T2 second be compared, and so forth if the Tuple contains more elements.
+     *
+     * @param o the specified object to compare this object with.
+     * @return a negative integer, zero, or a positive integer as this object is
+     * less than, equal to, or greater than the specified object.
+     * @throws IllegalArgumentException if o is null
+     */
+    @Override
+    public int compareTo(Tuple3<T1, T2, T3> o) {
+
+        if(o == null) {
+            throw new IllegalArgumentException("Cannot compare with null");
+        }
+
+        int isFirstElementsEqual = first.compareTo(o.first);
+
+        if(isFirstElementsEqual != 0) {
+            return isFirstElementsEqual;
+        }
+
+        int isSecondElementsEqual = second.compareTo(o.second);
+
+        return isSecondElementsEqual != 0 ? isSecondElementsEqual: third.compareTo(o.third);
+    }
+
+    /**
+     * Checks if this Tuple object is equal to the specified other object.
+     * The objects are only equal if the order of their elements are the same.
+     * This means that a tuple with elements (1, "two", 3.0) is not the same as one with elements (3.0, "two", 1).
+     *
+     * @param o other object to which this object will be compared with
+     * @return true if o is equal to this or if o contains the same elements in the same order as this, else false.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Tuple3<?, ?, ?> tuple3)) return false;
+        return Objects.equals(first, tuple3.first) && Objects.equals(second, tuple3.second) && Objects.equals(third, tuple3.third);
+    }
+
+    /**
+     * @return the hash code for this tuple
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(first, second, third);
+    }
+
+    /**
+     * @return a string representation of this tuple
+     */
+    @Override
+    public String toString() {
+        return "Tuple3{" +
+                "first=" + first +
+                ", second=" + second +
+                ", third=" + third +
+                '}';
+    }
+
+    /**
+     * Checks if passed functionResult is null and throws a IllegalArgumentException if true.
+     *
+     * @param functionResult the result of the function
+     * @param <R>            class type for the result of the function
+     * @throws IllegalArgumentException if functionResult is null
+     */
+    private <R> R checkForNullFunctionResult(R functionResult) {
+        if (functionResult == null) {
+            throw new IllegalArgumentException("Function result cannot be null. Functions must return non-null values.");
+        }
+        return functionResult;
+    }
+}

--- a/src/main/java/org/fungover/breeze/control/Tuple3.java
+++ b/src/main/java/org/fungover/breeze/control/Tuple3.java
@@ -43,7 +43,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
      *
      * @param first  first element of the tuple
      * @param second second element of the tuple
-     * @param third third element of the tuple
+     * @param third  third element of the tuple
      */
     private Tuple3(T1 first, T2 second, T3 third) {
         this.first = first;
@@ -56,7 +56,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
      *
      * @param first  first not null element in the tuple
      * @param second second not null element in the tuple
-     * @param third third not null element in the tuple
+     * @param third  third not null element in the tuple
      * @param <T1>   class type of first element where class must implement serializable and class (or superclass) must implement comparable.
      * @param <T2>   class type of second element where class must implement serializable and class (or superclass) must implement comparable.
      * @param <T3>   class type of third element where class must implement serializable and class (or superclass) must implement comparable.
@@ -74,6 +74,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the first element of this tuple
+     *
      * @return first
      */
     public T1 _1() {
@@ -82,6 +83,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the second element of this tuple
+     *
      * @return second
      */
     public T2 _2() {
@@ -90,6 +92,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the third element of this tuple
+     *
      * @return third
      */
     public T3 _3() {
@@ -98,6 +101,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the first element of this tuple
+     *
      * @return first
      */
     public T1 first() {
@@ -106,6 +110,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the second element of this tuple
+     *
      * @return second
      */
     public T2 second() {
@@ -114,6 +119,7 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the third element of this tuple
+     *
      * @return second
      */
     public T3 third() {
@@ -235,19 +241,19 @@ public final class Tuple3<T1 extends Comparable<? super T1> & Serializable, T2 e
     @Override
     public int compareTo(Tuple3<T1, T2, T3> o) {
 
-        if(o == null) {
+        if (o == null) {
             throw new IllegalArgumentException("Cannot compare with null");
         }
 
         int isFirstElementsEqual = first.compareTo(o.first);
 
-        if(isFirstElementsEqual != 0) {
+        if (isFirstElementsEqual != 0) {
             return isFirstElementsEqual;
         }
 
         int isSecondElementsEqual = second.compareTo(o.second);
 
-        return isSecondElementsEqual != 0 ? isSecondElementsEqual: third.compareTo(o.third);
+        return isSecondElementsEqual != 0 ? isSecondElementsEqual : third.compareTo(o.third);
     }
 
     /**

--- a/src/main/java/org/fungover/breeze/control/Tuple4.java
+++ b/src/main/java/org/fungover/breeze/control/Tuple4.java
@@ -1,0 +1,354 @@
+package org.fungover.breeze.control;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Final class that defines a comparable Tuple with an element size of 4.
+ * The class implements Comparable and Serializable.
+ * A tuple is useful for storing objects of equal or different class types.
+ * <p>
+ * Initialize: Tuple4.of(1, "two", 3.0, 'f');
+ * <p>
+ * All fields are set as private and final.
+ * Factory method of() to initialize new instance.
+ * Methods that produce a change in any element returns a new instance.
+ * Any call to methods in this class with a null object will result in a NullPointerException.
+ *
+ * @param <T1> class type of first element where class must implement serializable and class (or superclass) must implement comparable.
+ * @param <T2> class type of second element where class must implement serializable and class (or superclass) must implement comparable.
+ * @param <T3> class type of third element where class must implement serializable and class (or superclass) must implement comparable.
+ * @param <T4> class type of fourth element where class must implement serializable and class (or superclass) must implement comparable.
+ */
+public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable> implements Serializable, Comparable<Tuple4<T1, T2, T3, T4>> {
+
+    /**
+     * This value represents the first element of this object.
+     */
+    private final T1 first;
+
+    /**
+     * This value represents the second element of this object.
+     */
+    private final T2 second;
+
+    /**
+     * This value represents the third element of this object.
+     */
+    private final T3 third;
+
+    /**
+     * This value represents the fourth element of this object.
+     */
+    private final T4 fourth;
+
+    /**
+     * Private constructor that initialize a new Tuple4 object.
+     *
+     * @param first  first element of the tuple
+     * @param second second element of the tuple
+     * @param third third element of the tuple
+     * @param fourth fourth element of the tuple
+     */
+    private Tuple4(T1 first, T2 second, T3 third, T4 fourth) {
+        this.first = first;
+        this.second = second;
+        this.third = third;
+        this.fourth = fourth;
+    }
+
+    /**
+     * Constructs a Tuple4 with 4 elements.
+     *
+     * @param first  first not null element in the tuple
+     * @param second second not null element in the tuple
+     * @param third third not null element in the tuple
+     * @param fourth fourth not null element in the tuple
+     * @param <T1>   class type of first element where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <T2>   class type of second element where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <T3>   class type of third element where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <T4>   class type of fourth element where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple4 with 4 elements
+     * @throws IllegalArgumentException if any argument is null
+     */
+    public static <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+    Tuple4<T1, T2, T3, T4> of(T1 first, T2 second, T3 third, T4 fourth) {
+
+        if (first == null || second == null || third == null || fourth == null) {
+            throw new IllegalArgumentException("Argument cannot be null");
+        }
+        return new Tuple4<>(first, second, third, fourth);
+    }
+
+    /**
+     * Returns the first element of this tuple
+     * @return first
+     */
+    public T1 _1() {
+        return first;
+    }
+
+    /**
+     * Returns the second element of this tuple
+     * @return second
+     */
+    public T2 _2() {
+        return second;
+    }
+
+    /**
+     * Returns the third element of this tuple
+     * @return third
+     */
+    public T3 _3() {
+        return third;
+    }
+
+    /**
+     * Returns the fourth element of this tuple
+     * @return fourth
+     */
+    public T4 _4() {
+        return fourth;
+    }
+
+    /**
+     * Returns the first element of this tuple
+     * @return first
+     */
+    public T1 first() {
+        return first;
+    }
+
+    /**
+     * Returns the second element of this tuple
+     * @return second
+     */
+    public T2 second() {
+        return second;
+    }
+
+    /**
+     * Returns the third element of this tuple
+     * @return second
+     */
+    public T3 third() {
+        return third;
+    }
+
+    /**
+     * Returns the fourth element of this tuple
+     * @return second
+     */
+    public T4 fourth() {
+        return fourth;
+    }
+
+    /**
+     * Applies specified function to the first element of this tuple object and returns
+     * a new Tuple4 object with the result of the function as its first element, this.second as its second element,
+     * this.third as its third element and this.fourth as its fourth element.
+     *
+     * @param function the function that should be applied on this objects first element
+     * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple4 with R first, T2 second, T3 third and T4 fourth as values.
+     * @throws IllegalArgumentException if result of the function (R) is null
+     */
+    public <R extends Comparable<? super R> & Serializable> Tuple4<R, T2, T3, T4> map1(Function<T1, R> function) {
+
+        R functionResult = checkForNullFunctionResult(function.apply(first));
+
+        return Tuple4.of(functionResult, second, third, fourth);
+    }
+
+    /**
+     * Applies the specified function to the second element of this tuple object and returns
+     * a new Tuple4 object with this.first as its first element, the result of the function as its second element,
+     * this.third as its third element and this.fourth as its fourth element.
+     *
+     * @param function the function that should be applied on this objects second element
+     * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple4 with T1 first, R second, T3 third and T4 fourth as values.
+     * @throws IllegalArgumentException if result of the function (R) is null
+     */
+    public <R extends Comparable<? super R> & Serializable> Tuple4<T1, R, T3, T4> map2(Function<T2, R> function) {
+
+        R functionResult = checkForNullFunctionResult(function.apply(second));
+
+        return Tuple4.of(first, functionResult, third, fourth);
+    }
+
+    /**
+     * Applies the specified function to the third element of this tuple object and returns
+     * a new Tuple4 object with this.first as its first element, this.second as its second element,
+     * the result of the function as its third element and this.fourth as its fourth element.
+     *
+     * @param function the function that should be applied on this objects third element
+     * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple4 with T1 first, T2 second, R third and T4 fourth as values.
+     * @throws IllegalArgumentException if result of the function (R) is null
+     */
+    public <R extends Comparable<? super R> & Serializable> Tuple4<T1, T2, R, T4> map3(Function<T3, R> function) {
+
+        R functionResult = checkForNullFunctionResult(function.apply(third));
+
+        return Tuple4.of(first, second, functionResult, fourth);
+    }
+
+    /**
+     * Applies the specified function to the fourth element of this tuple object and returns
+     * a new Tuple4 object with this.first as its first element, this.second as its second element,
+     * this.third as its third element and the result of the function as its fourth element.
+     *
+     * @param function the function that should be applied on this objects fourth element
+     * @param <R>      class type of the element that results from the function where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple4 with T1 first, T2 second, T3 third and R fourth as values.
+     * @throws IllegalArgumentException if result of the function (R) is null
+     */
+    public <R extends Comparable<? super R> & Serializable> Tuple4<T1, T2, T3, R> map4(Function<T4, R> function) {
+
+        R functionResult = checkForNullFunctionResult(function.apply(fourth));
+
+        return Tuple4.of(first, second, third, functionResult);
+    }
+
+
+    /**
+     * Applies the specified functions to this tuple objects elements and returns
+     * a new Tuple4 object with the results of the functions its elements.
+     *
+     * @param function1 the function that should be applied on this objects first element
+     * @param function2 the function that should be applied on this objects second element
+     * @param function3 the function that should be applied on this objects third element
+     * @param function4 the function that should be applied on this objects fourth element
+     * @param <R1>      class type of the element that results from function1 where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <R2>      class type of the element that results from function2 where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <R3>      class type of the element that results from function3 where class must implement serializable and class (or superclass) must implement comparable.
+     * @param <R4>      class type of the element that results from function4 where class must implement serializable and class (or superclass) must implement comparable.
+     * @return a new Tuple4 with R1 first, R2 second, R3 third and R4 fourth as values.
+     * @throws IllegalArgumentException if result of any function (R1, R2, R3 or R4) is null
+     */
+    public <R1 extends Comparable<? super R1> & Serializable, R2 extends Comparable<? super R2> & Serializable, R3 extends Comparable<? super R3> & Serializable, R4 extends Comparable<? super R4> & Serializable>
+    Tuple4<R1, R2, R3, R4> mapAll(Function<T1, R1> function1, Function<T2, R2> function2, Function<T3, R3> function3, Function<T4, R4> function4) {
+
+        R1 firstFunctionResult = checkForNullFunctionResult(function1.apply(first));
+        R2 secondFunctionResult = checkForNullFunctionResult(function2.apply(second));
+        R3 thirdFunctionResult = checkForNullFunctionResult(function3.apply(third));
+        R4 fourthFunctionResult = checkForNullFunctionResult(function4.apply(fourth));
+
+        return Tuple4.of(firstFunctionResult, secondFunctionResult, thirdFunctionResult, fourthFunctionResult);
+    }
+
+    /**
+     * Converts this tuple objects elements into an Object[] array.
+     * The order of the elements in this object will transpose to the Object[] array order,
+     * meaning that this.first will be at index 0 of the array, this.second will be at index 1,
+     * and so forth if this object contains more elements.
+     *
+     * @return a new Object[] array containing the elements of this tuple object.
+     */
+    public Object[] toArray() {
+        return new Object[]{first, second, third, fourth};
+    }
+
+    /**
+     * Converts this tuple objects elements into an immutable List of type Object.
+     * The order of the elements in this object will transpose to list order,
+     * meaning that this.first will be at index 0 of the list, this.second will be at index 1,
+     * and so forth if this object contains more elements.
+     *
+     * @return an immutable List of type Object containing the elements of this tuple object.
+     */
+    public List<Object> toList() {
+        return List.of(first, second, third, fourth);
+    }
+
+    /**
+     * Compares this object with the specified object for order.
+     * The order of one Tuple compared with another Tuple is dependent on
+     * their elements order where the first element is prioritized,
+     * and the rest are sequentially following.
+     * This means that element T1 first is initially compared between the Tuple objects and
+     * only if they are equal will T2 second be compared, and so forth if the Tuple contains more elements.
+     *
+     * @param o the specified object to compare this object with.
+     * @return a negative integer, zero, or a positive integer as this object is
+     * less than, equal to, or greater than the specified object.
+     * @throws IllegalArgumentException if o is null
+     */
+    @Override
+    public int compareTo(Tuple4<T1, T2, T3, T4> o) {
+
+        if(o == null) {
+            throw new IllegalArgumentException("Cannot compare with null");
+        }
+
+        int isFirstElementsEqual = first.compareTo(o.first);
+
+        if(isFirstElementsEqual != 0) {
+            return isFirstElementsEqual;
+        }
+
+        int isSecondElementsEqual = second.compareTo(o.second);
+
+        if(isSecondElementsEqual != 0) {
+            return isSecondElementsEqual;
+        }
+
+        int isThirdElementsEqual = third.compareTo(o.third);
+
+        return isThirdElementsEqual != 0 ? isThirdElementsEqual: fourth.compareTo(o.fourth);
+    }
+
+    /**
+     * Checks if this Tuple object is equal to the specified other object.
+     * The objects are only equal if the order of their elements are the same.
+     * This means that a tuple with elements (1, "two", 3.0, 4) is not the same as one with elements (4, "two", 3.0, 1).
+     *
+     * @param o other object to which this object will be compared with
+     * @return true if o is equal to this or if o contains the same elements in the same order as this, else false.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Tuple4<?, ?, ?, ?> tuple4)) return false;
+        return Objects.equals(first, tuple4.first) && Objects.equals(second, tuple4.second) && Objects.equals(third, tuple4.third) && Objects.equals(fourth, tuple4.fourth);
+    }
+
+    /**
+     * @return the hash code for this tuple
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(first, second, third, fourth);
+    }
+
+    /**
+     * @return a string representation of this tuple
+     */
+    @Override
+    public String toString() {
+        return "Tuple4{" +
+                "first=" + first +
+                ", second=" + second +
+                ", third=" + third +
+                ", fourth=" + fourth +
+                '}';
+    }
+
+    /**
+     * Checks if passed functionResult is null and throws a IllegalArgumentException if true.
+     *
+     * @param functionResult the result of the function
+     * @param <R>            class type for the result of the function
+     * @throws IllegalArgumentException if functionResult is null
+     */
+    private <R> R checkForNullFunctionResult(R functionResult) {
+        if (functionResult == null) {
+            throw new IllegalArgumentException("Function result cannot be null. Functions must return non-null values.");
+        }
+        return functionResult;
+    }
+}

--- a/src/main/java/org/fungover/breeze/control/Tuple4.java
+++ b/src/main/java/org/fungover/breeze/control/Tuple4.java
@@ -15,7 +15,6 @@ import java.util.function.Function;
  * All fields are set as private and final.
  * Factory method of() to initialize new instance.
  * Methods that produce a change in any element returns a new instance.
- * Any call to methods in this class with a null object will result in a NullPointerException.
  *
  * @param <T1> class type of first element where class must implement serializable and class (or superclass) must implement comparable.
  * @param <T2> class type of second element where class must implement serializable and class (or superclass) must implement comparable.
@@ -139,7 +138,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
     /**
      * Returns the third element of this tuple
      *
-     * @return second
+     * @return third
      */
     public T3 third() {
         return third;
@@ -148,7 +147,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
     /**
      * Returns the fourth element of this tuple
      *
-     * @return second
+     * @return fourth
      */
     public T4 fourth() {
         return fourth;

--- a/src/main/java/org/fungover/breeze/control/Tuple4.java
+++ b/src/main/java/org/fungover/breeze/control/Tuple4.java
@@ -250,6 +250,46 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
     }
 
     /**
+     * Drops the first element and returns a new Tuple3 with:
+     * this.second as first, this.third as second and this.fourth as third.
+     *
+     * @return new Tuple3 object
+     */
+    public Tuple3<T2, T3, T4> dropFirst() {
+        return Tuple3.of(second, third, fourth);
+    }
+
+    /**
+     * Drops the second element and returns a new Tuple3 with:
+     * this.first as first, this.third as second and this.fourth as third.
+     *
+     * @return new Tuple3 object
+     */
+    public Tuple3<T1, T3, T4> dropSecond() {
+        return Tuple3.of(first, third, fourth);
+    }
+
+    /**
+     * Drops the third element and returns a new Tuple3 with:
+     * this.first as first, this.second as second and this.fourth as third.
+     *
+     * @return new Tuple3 object
+     */
+    public Tuple3<T1, T2, T4> dropThird() {
+        return Tuple3.of(first, second, fourth);
+    }
+
+    /**
+     * Drops the fourth element and returns a new Tuple3 with:
+     * this.first as first, this.second as second and this.third as third.
+     *
+     * @return new Tuple3 object
+     */
+    public Tuple3<T1, T2, T3> dropFourth() {
+        return Tuple3.of(first, second, third);
+    }
+
+    /**
      * Converts this tuple objects elements into an Object[] array.
      * The order of the elements in this object will transpose to the Object[] array order,
      * meaning that this.first will be at index 0 of the array, this.second will be at index 1,

--- a/src/main/java/org/fungover/breeze/control/Tuple4.java
+++ b/src/main/java/org/fungover/breeze/control/Tuple4.java
@@ -49,7 +49,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
      *
      * @param first  first element of the tuple
      * @param second second element of the tuple
-     * @param third third element of the tuple
+     * @param third  third element of the tuple
      * @param fourth fourth element of the tuple
      */
     private Tuple4(T1 first, T2 second, T3 third, T4 fourth) {
@@ -64,7 +64,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
      *
      * @param first  first not null element in the tuple
      * @param second second not null element in the tuple
-     * @param third third not null element in the tuple
+     * @param third  third not null element in the tuple
      * @param fourth fourth not null element in the tuple
      * @param <T1>   class type of first element where class must implement serializable and class (or superclass) must implement comparable.
      * @param <T2>   class type of second element where class must implement serializable and class (or superclass) must implement comparable.
@@ -84,6 +84,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the first element of this tuple
+     *
      * @return first
      */
     public T1 _1() {
@@ -92,6 +93,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the second element of this tuple
+     *
      * @return second
      */
     public T2 _2() {
@@ -100,6 +102,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the third element of this tuple
+     *
      * @return third
      */
     public T3 _3() {
@@ -108,6 +111,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the fourth element of this tuple
+     *
      * @return fourth
      */
     public T4 _4() {
@@ -116,6 +120,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the first element of this tuple
+     *
      * @return first
      */
     public T1 first() {
@@ -124,6 +129,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the second element of this tuple
+     *
      * @return second
      */
     public T2 second() {
@@ -132,6 +138,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the third element of this tuple
+     *
      * @return second
      */
     public T3 third() {
@@ -140,6 +147,7 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
 
     /**
      * Returns the fourth element of this tuple
+     *
      * @return second
      */
     public T4 fourth() {
@@ -281,25 +289,25 @@ public final class Tuple4<T1 extends Comparable<? super T1> & Serializable, T2 e
     @Override
     public int compareTo(Tuple4<T1, T2, T3, T4> o) {
 
-        if(o == null) {
+        if (o == null) {
             throw new IllegalArgumentException("Cannot compare with null");
         }
 
         int isFirstElementsEqual = first.compareTo(o.first);
 
-        if(isFirstElementsEqual != 0) {
+        if (isFirstElementsEqual != 0) {
             return isFirstElementsEqual;
         }
 
         int isSecondElementsEqual = second.compareTo(o.second);
 
-        if(isSecondElementsEqual != 0) {
+        if (isSecondElementsEqual != 0) {
             return isSecondElementsEqual;
         }
 
         int isThirdElementsEqual = third.compareTo(o.third);
 
-        return isThirdElementsEqual != 0 ? isThirdElementsEqual: fourth.compareTo(o.fourth);
+        return isThirdElementsEqual != 0 ? isThirdElementsEqual : fourth.compareTo(o.fourth);
     }
 
     /**

--- a/src/test/java/org/fungover/breeze/control/Tuple3Test.java
+++ b/src/test/java/org/fungover/breeze/control/Tuple3Test.java
@@ -1,0 +1,414 @@
+package org.fungover.breeze.control;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.Serializable;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+
+class Tuple3Test {
+
+    @Nested
+    class Initialization {
+
+        @Test
+        @DisplayName("Call to .of() method with any null argument should throw IllegalArgumentException")
+        void callToOfGivenAnyNullArgumentShouldThrowIllegalArgumentException() {
+
+            assertAll(
+                    () -> assertThatThrownBy(() -> Tuple3.of(null, 1, 1))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Argument cannot be null"),
+                    () -> assertThatThrownBy(() -> Tuple3.of(1, null, 1))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Argument cannot be null"),
+                    () -> assertThatThrownBy(() -> Tuple3.of(1, 1, null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Argument cannot be null")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to .of() method with valid arguments should return new Tuple3 object with passed arguments.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToOfGivenValidArgumentsShouldReturnNewTuple3WithPassedArguments(T1 o1, T2 o2, T3 o3) {
+
+            assertAll(
+                    () -> assertThat(Tuple3.of(o1, o2, o3).first()).isEqualTo(o1),
+                    () -> assertThat(Tuple3.of(o1, o2, o3).second()).isEqualTo(o2),
+                    () -> assertThat(Tuple3.of(o1, o2, o3).third()).isEqualTo(o3)
+            );
+        }
+    }
+
+    @Nested
+    class Elements {
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to first should return value of first.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToFirstShouldReturnFirstElement(T1 o1, T2 o2, T3 o3) {
+
+            assertThat(Tuple3.of(o1, o2, o3).first()).isEqualTo(o1);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to _1 should return value of first.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callTo_1ShouldReturnFirstElement(T1 o1, T2 o2, T3 o3) {
+
+            assertThat(Tuple3.of(o1, o2, o3)._1()).isEqualTo(o1);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to second should return value of second.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToSecondShouldReturnSecondElement(T1 o1, T2 o2, T3 o3) {
+
+            assertThat(Tuple3.of(o1, o2, o3).second()).isEqualTo(o2);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to _2 should return value of second.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callTo_2ShouldReturnSecondElement(T1 o1, T2 o2, T3 o3) {
+
+            assertThat(Tuple3.of(o1, o2, o3)._2()).isEqualTo(o2);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to third should return value of third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToThirdShouldReturnThirdElement(T1 o1, T2 o2, T3 o3) {
+
+            assertThat(Tuple3.of(o1, o2, o3).third()).isEqualTo(o3);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to _3 should return value of third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callTo_3ShouldReturnThirdElement(T1 o1, T2 o2, T3 o3) {
+
+            assertThat(Tuple3.of(o1, o2, o3)._3()).isEqualTo(o3);
+        }
+    }
+
+    @Nested
+    class Transformation {
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to map1 should apply function to first and return a new Tuple3 with the function-result as first, o2 as second and o3 as third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToMap1ShouldReturnNewTuple3WithFunctionResultAsFirst(T1 o1, T2 o2, T3 o3) {
+
+            var map1 = Tuple3.of(o1, o2, o3).map1(e -> 1);
+
+            assertAll(
+                    () -> assertThat(map1.first()).isEqualTo(1),
+                    () -> assertThat(map1.second()).isEqualTo(o2),
+                    () -> assertThat(map1.third()).isEqualTo(o3)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to map2 should apply function to second and return a new Tuple3 with o1 as first, the function-result as second and o3 as third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToMap2ShouldReturnNewTuple3WithFunctionResultAsSecond(T1 o1, T2 o2, T3 o3) {
+
+            var map2 = Tuple3.of(o1, o2, o3).map2(e -> 1);
+
+            assertAll(
+                    () -> assertThat(map2.first()).isEqualTo(o1),
+                    () -> assertThat(map2.second()).isEqualTo(1),
+                    () -> assertThat(map2.third()).isEqualTo(o3)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to map3 should apply function to third and return a new Tuple3 with o1 as first, o2 as second and the function-result as third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToMap3ShouldReturnNewTuple3WithFunctionResultAsThird(T1 o1, T2 o2, T3 o3) {
+
+            var map3 = Tuple3.of(o1, o2, o3).map3(e -> 1);
+
+            assertAll(
+                    () -> assertThat(map3.first()).isEqualTo(o1),
+                    () -> assertThat(map3.second()).isEqualTo(o2),
+                    () -> assertThat(map3.third()).isEqualTo(1)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to mapAll should apply specified functions to first, second and third and return a new Tuple3 with the functions-result as element values.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToMapAllShouldReturnNewTuple3WithFunctionsResultAsElementValues(T1 o1, T2 o2, T3 o3) {
+
+            var mapAll = Tuple3.of(o1, o2, o3).mapAll(e -> 1, e2 -> 1, e3 -> 1);
+
+            assertAll(
+                    () -> assertThat(mapAll.first()).isEqualTo(1),
+                    () -> assertThat(mapAll.second()).isEqualTo(1),
+                    () -> assertThat(mapAll.third()).isEqualTo(1)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to any map method should not change calling object")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToAnyMapMethodShouldNotChangeCallingObject(T1 o1, T2 o2, T3 o3) {
+
+            var tuple = Tuple3.of(o1, o2, o3);
+
+            tuple.map1(e -> 1);
+            tuple.map2(e -> 1);
+            tuple.map3(e -> 1);
+            tuple.mapAll(e1 -> 1, e2 -> 1, e3 -> 1);
+
+            assertThat(tuple).isEqualTo(Tuple3.of(o1, o2, o3));
+        }
+
+        @Test
+        @DisplayName("Call to all map methods with null function should trigger IllegalArgumentException")
+        void callToAnyMapMethodWithNullFunctionShouldTriggerIllegalArgumentException() {
+
+            var tuple = Tuple3.of("s", "s", "s");
+
+            assertAll(
+                    () -> assertThatThrownBy(() -> tuple.map1(e -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values."),
+                    () -> assertThatThrownBy(() -> tuple.map2(e -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values."),
+                    () -> assertThatThrownBy(() -> tuple.map3(e -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values."),
+                    () -> assertThatThrownBy(() -> tuple.mapAll(e1 -> null, e2 -> null, e3 -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values.")
+            );
+        }
+
+        @Test
+        @DisplayName("Call to map1 with string function should change first element")
+        void callToMap1WithStringFunctionShouldChangeFirstElement() {
+
+            var tuple = Tuple3.of("A", "A", "A");
+            var map1 = tuple.map1(e -> e.concat("BC"));
+
+            assertThat(map1.first()).isEqualTo("ABC");
+        }
+
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to toArray should return Object[] with Tuple3 object elements")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToToArrayShouldReturnObjectArrayWithTuple3Elements(T1 o1, T2 o2, T3 o3) {
+
+            var tuple = Tuple3.of(o1, o2, o3);
+            var array = tuple.toArray();
+
+            assertAll(
+                    () -> assertThat(array).hasSize(3),
+                    () -> assertThat(array[0]).isEqualTo(o1),
+                    () -> assertThat(array[1]).isEqualTo(o2),
+                    () -> assertThat(array[2]).isEqualTo(o3)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to toList should return List<Object> with Tuple3 object elements")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToToListShouldReturnListOfObjectWithTuple3Elements(T1 o1, T2 o2, T3 o3) {
+
+            var tuple = Tuple3.of(o1, o2, o3);
+            var list = tuple.toList();
+
+            assertAll(
+                    () -> assertThat(list).hasSize(3),
+                    () -> assertThat(list.getFirst()).isEqualTo(o1),
+                    () -> assertThat(list.get(1)).isEqualTo(o2),
+                    () -> assertThat(list.get(2)).isEqualTo(o3)
+            );
+        }
+    }
+
+    @Nested
+    class ComparisonAndToString {
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to compareTo should return 0 for equal Tuple objects (contains the same elements).")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToCompareToShouldReturnZeroForEqual(T1 o1, T2 o2, T3 o3) {
+
+            var tupleA = Tuple3.of(o1, o2, o3);
+            var tupleB = Tuple3.of(o1, o2, o3);
+
+            assertThat(tupleA.compareTo(tupleB)).isEqualByComparingTo(0);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1, 1, 1, 1, 1, 2",
+                "1, 1, 1, 1, 2, 1",
+                "1, 1, 1, 2, 1, 1",
+                "A, A, A, A, A, B",
+                "A, A, A, A, B, A",
+                "A, A, A, B, A, A"
+        })
+        @DisplayName("Call to compareTo should return negative integer for a Tuple object that is lesser than passed object.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToCompareToShouldReturnNegativeIntegerForLesser(T1 m1, T2 m2, T3 m3, T1 l1, T2 l2, T3 l3) {
+
+            var tupleA = Tuple3.of(m1, m2, m3);
+            var tupleB = Tuple3.of(l1, l2, l3);
+
+            assertThat(tupleA.compareTo(tupleB)).isNegative();
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1, 1, 2, 1, 1, 1",
+                "1, 2, 1, 1, 1, 1",
+                "2, 1, 1, 1, 1, 1",
+                "A, A, B, A, A, A",
+                "A, B, A, A, A, A",
+                "B, A, A, A, A, A"
+        })
+        @DisplayName("Call to compareTo should return positive integer for a Tuple object that is greater than passed object.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToCompareToShouldReturnPositiveIntegerForGreater(T1 m1, T2 m2, T3 m3, T1 l1, T2 l2, T3 l3) {
+
+            var tupleA = Tuple3.of(m1, m2, m3);
+            var tupleB = Tuple3.of(l1, l2, l3);
+
+            assertThat(tupleA.compareTo(tupleB)).isPositive();
+        }
+
+        @Test
+        @DisplayName("Call to compareTo should throw IllegalArgumentException for null argument.")
+        void callToCompareToShouldThrowIllegalArgumentExceptionForNullArgument() {
+
+            var tupleA = Tuple3.of(1, 1, 1);
+
+            assertThatThrownBy(() -> tupleA.compareTo(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Cannot compare with null");
+        }
+
+        @Test
+        @DisplayName("Call to equals should return false for null argument")
+        void callToEqualsShouldReturnFalseForNullArgument() {
+
+            var tuple = Tuple3.of(1, 2, 3);
+
+            assertThat(tuple.equals(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("Call to hashCode with equal Tuple objects should return equal hashcodes")
+        void callToHashCodeWithEqualObjectsShouldReturnEqualHashCode() {
+
+            var tupleA = Tuple3.of(1, "two", 3);
+            var tupleB = Tuple3.of(1, "two", 3);
+
+            assertThat(tupleA.hashCode()).hasSameHashCodeAs(tupleB.hashCode());
+        }
+
+        @Test
+        @DisplayName("Call to hashCode with unequal Tuple objects should return not equal hashcodes")
+        void callToHashCodeWithUnequalObjectsShouldReturnNotEqualHashCode() {
+
+            var tupleA = Tuple3.of(1, "two", 3);
+            var tupleB = Tuple3.of(3, "two", 1);
+
+            assertThat(tupleA.hashCode()).doesNotHaveSameHashCodeAs(tupleB.hashCode());
+        }
+
+        @Test
+        @DisplayName("Call to toString should return specified string with elements")
+        void callToToStringShouldReturnSpecifiedStringWithElements() {
+
+            var tupleInteger = Tuple3.of(1, 2, 3).toString();
+            var tupleString = Tuple3.of("A", "B", "C").toString();
+
+            assertAll(
+                    () -> assertThat(tupleInteger).isEqualTo("Tuple3{first=1, second=2, third=3}"),
+                    () -> assertThat(tupleString).isEqualTo("Tuple3{first=A, second=B, third=C}")
+            );
+
+        }
+    }
+
+    static Stream<Arguments> validArgumentsForCreationOfTuple3() {
+
+        class MyClass implements Comparable<MyClass>, Serializable {
+
+            /**
+             * Only for test.
+             * @param o the object to be compared.
+             * @return 0 as all objects should be considered equal
+             */
+            @Override
+            public int compareTo(MyClass o) {
+                return 0;
+            }
+        }
+
+        class MySubClass extends MyClass {
+            /**
+             * Only for test.
+             * @param o the object to be compared.
+             * @return 0 if instance of MySubClass, else 1.
+             */
+            @Override
+            public int compareTo(MyClass o) {
+                if (o instanceof MySubClass) {
+                    return 0;
+                }
+                return 1;
+            }
+        }
+
+        var myClass = new MyClass();
+        var mySubClass = new MySubClass();
+
+        return Stream.of(
+                Arguments.of(myClass, myClass, myClass),
+                Arguments.of(1, 2, 3),
+                Arguments.of(1.0, 2.0, 3.0),
+                Arguments.of(1.0f, 2.0f, 3.0f),
+                Arguments.of("s", "s", "s"),
+                Arguments.of(1, "s", 3.0),
+                Arguments.of(1.0, 'c', 3.0f),
+                Arguments.of(myClass, "s", mySubClass),
+                Arguments.of(2.0, myClass, 'M'),
+                Arguments.of(mySubClass, myClass, 3),
+                Arguments.of("Hello\n\t", "World\r\n", "!\n"),
+                Arguments.of(Integer.MAX_VALUE, Integer.MIN_VALUE, 1)
+        );
+    }
+}

--- a/src/test/java/org/fungover/breeze/control/Tuple3Test.java
+++ b/src/test/java/org/fungover/breeze/control/Tuple3Test.java
@@ -253,6 +253,109 @@ class Tuple3Test {
                     () -> assertThat(list.get(2)).isEqualTo(o3)
             );
         }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to append should return a new Tuple4 with specified E element as forth element")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToAppendShouldReturnATuple4(T1 o1, T2 o2, T3 o3) {
+
+            var element = "NEW ELEMENT";
+            var tuple3 = Tuple3.of(o1, o2, o3);
+            var tuple4 = tuple3.append(element);
+
+            assertAll(
+                    () -> assertThat(tuple4.first()).isEqualTo(o1),
+                    () -> assertThat(tuple4.second()).isEqualTo(o2),
+                    () -> assertThat(tuple4.third()).isEqualTo(o3),
+                    () -> assertThat(tuple4.fourth()).isEqualTo(element)
+            );
+        }
+
+        @Test
+        @DisplayName("Call to append should throw IllegalArgumentException for null argument")
+        void callToAppendShouldThrowIllegalArgumentExceptionForNullArgument() {
+
+            var tuple = Tuple3.of(1, "two", 3);
+
+            assertThatThrownBy(() -> tuple.append(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Cannot append a null element");
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to prepend should return a new Tuple4 with specified E element as first element")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToPrependShouldReturnATuple4(T1 o1, T2 o2, T3 o3) {
+
+            var element = "NEW ELEMENT";
+            var tuple3 = Tuple3.of(o1, o2, o3);
+            var tuple4 = tuple3.prepend(element);
+
+            assertAll(
+                    () -> assertThat(tuple4.first()).isEqualTo(element),
+                    () -> assertThat(tuple4.second()).isEqualTo(o1),
+                    () -> assertThat(tuple4.third()).isEqualTo(o2),
+                    () -> assertThat(tuple4.fourth()).isEqualTo(o3)
+            );
+        }
+
+        @Test
+        @DisplayName("Call to prepend should throw IllegalArgumentException for null argument")
+        void callToPrependShouldThrowIllegalArgumentExceptionForNullArgument() {
+
+            var tuple = Tuple3.of(1, "two", 3);
+
+            assertThatThrownBy(() -> tuple.prepend(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Cannot prepend a null element");
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to dropFirst should return a new Tuple2 with this.second as first and this.third as second.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToDropFirstShouldReturnATuple2(T1 o1, T2 o2, T3 o3) {
+
+            var tuple3 = Tuple3.of(o1, o2, o3);
+            var tuple2 = tuple3.dropFirst();
+
+            assertAll(
+                    () -> assertThat(tuple2.first()).isEqualTo(o2),
+                    () -> assertThat(tuple2.second()).isEqualTo(o3)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to dropSecond should return a new Tuple2 with this.first as first and this.third as second.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToDropSecondShouldReturnATuple2(T1 o1, T2 o2, T3 o3) {
+
+            var tuple3 = Tuple3.of(o1, o2, o3);
+            var tuple2 = tuple3.dropSecond();
+
+            assertAll(
+                    () -> assertThat(tuple2.first()).isEqualTo(o1),
+                    () -> assertThat(tuple2.second()).isEqualTo(o3)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple3Test#validArgumentsForCreationOfTuple3")
+        @DisplayName("Call to dropThird should return a new Tuple2 with this.first as first and this.second as second.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable>
+        void callToDropThirdShouldReturnATuple2(T1 o1, T2 o2, T3 o3) {
+
+            var tuple3 = Tuple3.of(o1, o2, o3);
+            var tuple2 = tuple3.dropThird();
+
+            assertAll(
+                    () -> assertThat(tuple2.first()).isEqualTo(o1),
+                    () -> assertThat(tuple2.second()).isEqualTo(o2)
+            );
+        }
     }
 
     @Nested
@@ -326,6 +429,15 @@ class Tuple3Test {
             var tuple = Tuple3.of(1, 2, 3);
 
             assertThat(tuple.equals(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("Call to equals should return true for comparison with itself")
+        void callToEqualsShouldReturnTrueForComparisonWithItself() {
+
+            var tuple = Tuple3.of(1, 2, 3);
+
+            assertThat(tuple.equals(tuple)).isTrue();
         }
 
         @Test

--- a/src/test/java/org/fungover/breeze/control/Tuple4Test.java
+++ b/src/test/java/org/fungover/breeze/control/Tuple4Test.java
@@ -1,0 +1,466 @@
+package org.fungover.breeze.control;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.Serializable;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+
+class Tuple4Test {
+
+    @Nested
+    class Initialization {
+
+        @Test
+        @DisplayName("Call to .of() method with any null argument should throw IllegalArgumentException")
+        void callToOfGivenAnyNullArgumentShouldThrowIllegalArgumentException() {
+
+            assertAll(
+                    () -> assertThatThrownBy(() -> Tuple4.of(null, 1, 1, 1))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Argument cannot be null"),
+                    () -> assertThatThrownBy(() -> Tuple4.of(1, null, 1, 1))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Argument cannot be null"),
+                    () -> assertThatThrownBy(() -> Tuple4.of(1, 1, null, 1))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Argument cannot be null"),
+                    () -> assertThatThrownBy(() -> Tuple4.of(1, 1, 1, null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Argument cannot be null")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to .of() method with valid arguments should return new Tuple4 object with passed arguments.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToOfGivenValidArgumentsShouldReturnNewTuple4WithPassedArguments(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertAll(
+                    () -> assertThat(Tuple4.of(o1, o2, o3, o4).first()).isEqualTo(o1),
+                    () -> assertThat(Tuple4.of(o1, o2, o3, o4).second()).isEqualTo(o2),
+                    () -> assertThat(Tuple4.of(o1, o2, o3, o4).third()).isEqualTo(o3),
+                    () -> assertThat(Tuple4.of(o1, o2, o3, o4).fourth()).isEqualTo(o4)
+            );
+        }
+    }
+
+    @Nested
+    class Elements {
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to first should return value of first.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToFirstShouldReturnFirstElement(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertThat(Tuple4.of(o1, o2, o3, o4).first()).isEqualTo(o1);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to _1 should return value of first.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callTo_1ShouldReturnFirstElement(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertThat(Tuple4.of(o1, o2, o3, o4)._1()).isEqualTo(o1);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to second should return value of second.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToSecondShouldReturnSecondElement(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertThat(Tuple4.of(o1, o2, o3, o4).second()).isEqualTo(o2);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to _2 should return value of second.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callTo_2ShouldReturnSecondElement(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertThat(Tuple4.of(o1, o2, o3, o4)._2()).isEqualTo(o2);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to third should return value of third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToThirdShouldReturnThirdElement(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertThat(Tuple4.of(o1, o2, o3, o4).third()).isEqualTo(o3);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to _3 should return value of third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callTo_3ShouldReturnThirdElement(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertThat(Tuple4.of(o1, o2, o3, o4)._3()).isEqualTo(o3);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to fourth should return value of fourth.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToFourthShouldReturnFourthElement(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertThat(Tuple4.of(o1, o2, o3, o4).fourth()).isEqualTo(o4);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to _4 should return value of fourth.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callTo_4ShouldReturnFourthElement(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            assertThat(Tuple4.of(o1, o2, o3, o4)._4()).isEqualTo(o4);
+        }
+    }
+
+    @Nested
+    class Transformation {
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to map1 should apply function to first and return a new Tuple4 with the function-result as first, o2 as second, o3 as third and o4 as fourth.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToMap1ShouldReturnNewTuple4WithFunctionResultAsFirst(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var map1 = Tuple4.of(o1, o2, o3, o4).map1(e -> 1);
+
+            assertAll(
+                    () -> assertThat(map1.first()).isEqualTo(1),
+                    () -> assertThat(map1.second()).isEqualTo(o2),
+                    () -> assertThat(map1.third()).isEqualTo(o3),
+                    () -> assertThat(map1.fourth()).isEqualTo(o4)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to map2 should apply function to second and return a new Tuple4 with o1 as first, the function-result as second, o3 as third and o4 as fourth.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToMap2ShouldReturnNewTuple4WithFunctionResultAsSecond(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var map2 = Tuple4.of(o1, o2, o3, o4).map2(e -> 1);
+
+            assertAll(
+                    () -> assertThat(map2.first()).isEqualTo(o1),
+                    () -> assertThat(map2.second()).isEqualTo(1),
+                    () -> assertThat(map2.third()).isEqualTo(o3),
+                    () -> assertThat(map2.fourth()).isEqualTo(o4)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to map3 should apply function to third and return a new Tuple4 with o1 as first, o2 as second, the function-result as third and o4 as fourth.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToMap3ShouldReturnNewTuple4WithFunctionResultAsThird(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var map3 = Tuple4.of(o1, o2, o3, o4).map3(e -> 1);
+
+            assertAll(
+                    () -> assertThat(map3.first()).isEqualTo(o1),
+                    () -> assertThat(map3.second()).isEqualTo(o2),
+                    () -> assertThat(map3.third()).isEqualTo(1),
+                    () -> assertThat(map3.fourth()).isEqualTo(o4)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to map4 should apply function to fourth and return a new Tuple4 with o1 as first, o2 as second, o3 as third and the function-result as fourth.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToMap4ShouldReturnNewTuple4WithFunctionResultAsFourth(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var map3 = Tuple4.of(o1, o2, o3, o4).map4(e -> 1);
+
+            assertAll(
+                    () -> assertThat(map3.first()).isEqualTo(o1),
+                    () -> assertThat(map3.second()).isEqualTo(o2),
+                    () -> assertThat(map3.third()).isEqualTo(o3),
+                    () -> assertThat(map3.fourth()).isEqualTo(1)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to mapAll should apply specified functions to first, second, third and fourth and return a new Tuple4 with the functions-result as element values.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToMapAllShouldReturnNewTuple4WithFunctionsResultAsElementValues(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var mapAll = Tuple4.of(o1, o2, o3, o4).mapAll(e -> 1, e2 -> 1, e3 -> 1, e4 -> 1);
+
+            assertAll(
+                    () -> assertThat(mapAll.first()).isEqualTo(1),
+                    () -> assertThat(mapAll.second()).isEqualTo(1),
+                    () -> assertThat(mapAll.third()).isEqualTo(1),
+                    () -> assertThat(mapAll.fourth()).isEqualTo(1)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to any map method should not change calling object")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToAnyMapMethodShouldNotChangeCallingObject(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var tuple = Tuple4.of(o1, o2, o3, o4);
+
+            tuple.map1(e -> 1);
+            tuple.map2(e -> 1);
+            tuple.map3(e -> 1);
+            tuple.map4(e -> 1);
+            tuple.mapAll(e1 -> 1, e2 -> 1, e3 -> 1, e4 -> 1);
+
+            assertThat(tuple).isEqualTo(Tuple4.of(o1, o2, o3, o4));
+        }
+
+        @Test
+        @DisplayName("Call to all map methods with null function should trigger IllegalArgumentException")
+        void callToAnyMapMethodWithNullFunctionShouldTriggerIllegalArgumentException() {
+
+            var tuple = Tuple4.of("s", "s", "s", "s");
+
+            assertAll(
+                    () -> assertThatThrownBy(() -> tuple.map1(e -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values."),
+                    () -> assertThatThrownBy(() -> tuple.map2(e -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values."),
+                    () -> assertThatThrownBy(() -> tuple.map3(e -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values."),
+                    () -> assertThatThrownBy(() -> tuple.map4(e -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values."),
+                    () -> assertThatThrownBy(() -> tuple.mapAll(e1 -> null, e2 -> null, e3 -> null, e4 -> null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Function result cannot be null. Functions must return non-null values.")
+            );
+        }
+
+        @Test
+        @DisplayName("Call to map1 with string function should change first element")
+        void callToMap1WithStringFunctionShouldChangeFirstElement() {
+
+            var tuple = Tuple4.of("A", "A", "A", "A");
+            var map1 = tuple.map1(e -> e.concat("BC"));
+
+            assertThat(map1.first()).isEqualTo("ABC");
+        }
+
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to toArray should return Object[] with Tuple4 object elements")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToToArrayShouldReturnObjectArrayWithTuple4Elements(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var tuple = Tuple4.of(o1, o2, o3, o4);
+            var array = tuple.toArray();
+
+            assertAll(
+                    () -> assertThat(array).hasSize(4),
+                    () -> assertThat(array[0]).isEqualTo(o1),
+                    () -> assertThat(array[1]).isEqualTo(o2),
+                    () -> assertThat(array[2]).isEqualTo(o3),
+                    () -> assertThat(array[3]).isEqualTo(o4)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to toList should return List<Object> with Tuple4 object elements")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToToListShouldReturnListOfObjectWithTuple4Elements(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var tuple = Tuple4.of(o1, o2, o3, o4);
+            var list = tuple.toList();
+
+            assertAll(
+                    () -> assertThat(list).hasSize(4),
+                    () -> assertThat(list.getFirst()).isEqualTo(o1),
+                    () -> assertThat(list.get(1)).isEqualTo(o2),
+                    () -> assertThat(list.get(2)).isEqualTo(o3),
+                    () -> assertThat(list.get(3)).isEqualTo(o4)
+            );
+        }
+    }
+
+    @Nested
+    class ComparisonAndToString {
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to compareTo should return 0 for equal Tuple objects (contains the same elements).")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToCompareToShouldReturnZeroForEqual(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var tupleA = Tuple4.of(o1, o2, o3, o4);
+            var tupleB = Tuple4.of(o1, o2, o3, o4);
+
+            assertThat(tupleA.compareTo(tupleB)).isEqualByComparingTo(0);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1, 1, 1, 1, 1, 1, 1, 2",
+                "1, 1, 1, 1, 1, 1, 2, 1",
+                "1, 1, 1, 1, 1, 2, 1, 1",
+                "1, 1, 1, 1, 2, 1, 1, 1",
+                "A, A, A, A, A, A, A, B",
+                "A, A, A, A, A, A, B, A",
+                "A, A, A, A, A, B, A, A",
+                "A, A, A, A, B, A, A, A"
+        })
+        @DisplayName("Call to compareTo should return negative integer for a Tuple object that is lesser than passed object.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToCompareToShouldReturnNegativeIntegerForLesser(T1 m1, T2 m2, T3 m3, T4 m4, T1 l1, T2 l2, T3 l3, T4 l4) {
+
+            var tupleA = Tuple4.of(m1, m2, m3, m4);
+            var tupleB = Tuple4.of(l1, l2, l3, l4);
+
+            assertThat(tupleA.compareTo(tupleB)).isNegative();
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1, 1, 1, 2, 1, 1, 1, 1",
+                "1, 1, 2, 1, 1, 1, 1, 1",
+                "1, 2, 1, 1, 1, 1, 1, 1",
+                "2, 1, 1, 1, 1, 1, 1, 1",
+                "A, A, A, B, A, A, A, A",
+                "A, A, B, A, A, A, A, A",
+                "A, B, A, A, A, A, A, A",
+                "B, A, A, A, A, A, A, A"
+        })
+        @DisplayName("Call to compareTo should return positive integer for a Tuple object that is greater than passed object.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToCompareToShouldReturnPositiveIntegerForGreater(T1 m1, T2 m2, T3 m3, T4 m4, T1 l1, T2 l2, T3 l3, T4 l4) {
+
+            var tupleA = Tuple4.of(m1, m2, m3, m4);
+            var tupleB = Tuple4.of(l1, l2, l3, l4);
+
+            assertThat(tupleA.compareTo(tupleB)).isPositive();
+        }
+
+        @Test
+        @DisplayName("Call to compareTo should throw IllegalArgumentException for null argument.")
+        void callToCompareToShouldThrowIllegalArgumentExceptionForNullArgument() {
+
+            var tupleA = Tuple4.of(1, 1, 1, 1);
+
+            assertThatThrownBy(() -> tupleA.compareTo(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Cannot compare with null");
+        }
+
+        @Test
+        @DisplayName("Call to equals should return false for null argument")
+        void callToEqualsShouldReturnFalseForNullArgument() {
+
+            var tuple = Tuple4.of(1, 1, 1, 1);
+
+            assertThat(tuple.equals(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("Call to hashCode with equal Tuple objects should return equal hashcodes")
+        void callToHashCodeWithEqualObjectsShouldReturnEqualHashCode() {
+
+            var tupleA = Tuple4.of(1, "two", 3.0, 4);
+            var tupleB = Tuple4.of(1, "two", 3.0, 4);
+
+            assertThat(tupleA.hashCode()).hasSameHashCodeAs(tupleB.hashCode());
+        }
+
+        @Test
+        @DisplayName("Call to hashCode with unequal Tuple objects should return not equal hashcodes")
+        void callToHashCodeWithUnequalObjectsShouldReturnNotEqualHashCode() {
+
+            var tupleA = Tuple4.of(1, "two", 3.0, 4);
+            var tupleB = Tuple4.of(4, "two", 3.0, 1);
+
+            assertThat(tupleA.hashCode()).doesNotHaveSameHashCodeAs(tupleB.hashCode());
+        }
+
+        @Test
+        @DisplayName("Call to toString should return specified string with elements")
+        void callToToStringShouldReturnSpecifiedStringWithElements() {
+
+            var tupleInteger = Tuple4.of(1, 2, 3, 4).toString();
+            var tupleString = Tuple4.of("A", "B", "C", "D").toString();
+
+            assertAll(
+                    () -> assertThat(tupleInteger).isEqualTo("Tuple4{first=1, second=2, third=3, fourth=4}"),
+                    () -> assertThat(tupleString).isEqualTo("Tuple4{first=A, second=B, third=C, fourth=D}")
+            );
+
+        }
+    }
+
+    static Stream<Arguments> validArgumentsForCreationOfTuple4() {
+
+        class MyClass implements Comparable<MyClass>, Serializable {
+
+            /**
+             * Only for test.
+             * @param o the object to be compared.
+             * @return 0 as all objects should be considered equal
+             */
+            @Override
+            public int compareTo(MyClass o) {
+                return 0;
+            }
+        }
+
+        class MySubClass extends MyClass {
+            /**
+             * Only for test.
+             * @param o the object to be compared.
+             * @return 0 if instance of MySubClass, else 1.
+             */
+            @Override
+            public int compareTo(MyClass o) {
+                if (o instanceof MySubClass) {
+                    return 0;
+                }
+                return 1;
+            }
+        }
+
+        var myClass = new MyClass();
+        var mySubClass = new MySubClass();
+
+        return Stream.of(
+                Arguments.of(myClass, myClass, myClass, myClass),
+                Arguments.of(1, 2, 3, 4),
+                Arguments.of(1.0, 2.0, 3.0, 4.0),
+                Arguments.of(1.0f, 2.0f, 3.0f, 4.0f),
+                Arguments.of("s", "s", "s", "s"),
+                Arguments.of(1, "s", 3.0, 's'),
+                Arguments.of(1.0, 'c', 3.0f, myClass),
+                Arguments.of("s", "s", mySubClass, 2),
+                Arguments.of(2.0, myClass, 'M', 'M'),
+                Arguments.of(mySubClass, myClass, 3, myClass),
+                Arguments.of("Hello\n\t", "World\r\n", "!\n", "\n"),
+                Arguments.of(Integer.MAX_VALUE, Integer.MIN_VALUE, 1, 2)
+        );
+    }
+}

--- a/src/test/java/org/fungover/breeze/control/Tuple4Test.java
+++ b/src/test/java/org/fungover/breeze/control/Tuple4Test.java
@@ -187,13 +187,13 @@ class Tuple4Test {
         <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
         void callToMap4ShouldReturnNewTuple4WithFunctionResultAsFourth(T1 o1, T2 o2, T3 o3, T4 o4) {
 
-            var map3 = Tuple4.of(o1, o2, o3, o4).map4(e -> 1);
+            var map4 = Tuple4.of(o1, o2, o3, o4).map4(e -> 1);
 
             assertAll(
-                    () -> assertThat(map3.first()).isEqualTo(o1),
-                    () -> assertThat(map3.second()).isEqualTo(o2),
-                    () -> assertThat(map3.third()).isEqualTo(o3),
-                    () -> assertThat(map3.fourth()).isEqualTo(1)
+                    () -> assertThat(map4.first()).isEqualTo(o1),
+                    () -> assertThat(map4.second()).isEqualTo(o2),
+                    () -> assertThat(map4.third()).isEqualTo(o3),
+                    () -> assertThat(map4.fourth()).isEqualTo(1)
             );
         }
 

--- a/src/test/java/org/fungover/breeze/control/Tuple4Test.java
+++ b/src/test/java/org/fungover/breeze/control/Tuple4Test.java
@@ -301,6 +301,70 @@ class Tuple4Test {
                     () -> assertThat(list.get(3)).isEqualTo(o4)
             );
         }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to dropFirst should return a new Tuple3 with this.second as first, this.third as second and this.fourth as third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToDropFirstShouldReturnATuple3(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var tuple4 = Tuple4.of(o1, o2, o3, o4);
+            var tuple3 = tuple4.dropFirst();
+
+            assertAll(
+                    () -> assertThat(tuple3.first()).isEqualTo(o2),
+                    () -> assertThat(tuple3.second()).isEqualTo(o3),
+                    () -> assertThat(tuple3.third()).isEqualTo(o4)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to dropSecond should return a new Tuple3 with this.first as first, this.third as second and this.fourth as third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToDropSecondShouldReturnATuple3(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var tuple4 = Tuple4.of(o1, o2, o3, o4);
+            var tuple3 = tuple4.dropSecond();
+
+            assertAll(
+                    () -> assertThat(tuple3.first()).isEqualTo(o1),
+                    () -> assertThat(tuple3.second()).isEqualTo(o3),
+                    () -> assertThat(tuple3.third()).isEqualTo(o4)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to dropThird should return a new Tuple3 with this.first as first, this.second as second and this.fourth as third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToDropThirdShouldReturnATuple3(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var tuple4 = Tuple4.of(o1, o2, o3, o4);
+            var tuple3 = tuple4.dropThird();
+
+            assertAll(
+                    () -> assertThat(tuple3.first()).isEqualTo(o1),
+                    () -> assertThat(tuple3.second()).isEqualTo(o2),
+                    () -> assertThat(tuple3.third()).isEqualTo(o4)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.fungover.breeze.control.Tuple4Test#validArgumentsForCreationOfTuple4")
+        @DisplayName("Call to dropFourth should return a new Tuple3 with this.first as first, this.second as second and this.third as third.")
+        <T1 extends Comparable<? super T1> & Serializable, T2 extends Comparable<? super T2> & Serializable, T3 extends Comparable<? super T3> & Serializable, T4 extends Comparable<? super T4> & Serializable>
+        void callToDropFourthShouldReturnATuple3(T1 o1, T2 o2, T3 o3, T4 o4) {
+
+            var tuple4 = Tuple4.of(o1, o2, o3, o4);
+            var tuple3 = tuple4.dropFourth();
+
+            assertAll(
+                    () -> assertThat(tuple3.first()).isEqualTo(o1),
+                    () -> assertThat(tuple3.second()).isEqualTo(o2),
+                    () -> assertThat(tuple3.third()).isEqualTo(o3)
+            );
+        }
     }
 
     @Nested
@@ -378,6 +442,15 @@ class Tuple4Test {
             var tuple = Tuple4.of(1, 1, 1, 1);
 
             assertThat(tuple.equals(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("Call to equals should return true for comparison with itself")
+        void callToEqualsShouldReturnTrueForComparisonWithItself() {
+
+            var tuple = Tuple4.of(1, 2, 3, 4);
+
+            assertThat(tuple.equals(tuple)).isTrue();
         }
 
         @Test


### PR DESCRIPTION
PR issue: #117 - Implement Tuple3 and Tuple4 classes
PR parent issue: #8 -  Implement Tuple types for immutable compound values
PR related issue: #65 - Implement Tuple2 class

These Tuple classes have been extended to include conversion between Tuples which the Tuple2 class do not have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced two new tuple data structures (`Tuple3` and `Tuple4`) that allow grouping three or four values, respectively, with built-in transformation, comparison, and conversion capabilities while enforcing non-null constraints.

- **Tests**
  - Added extensive test suites for `Tuple3` and `Tuple4` to validate their functionality and robustness across various use cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->