### PR TITLE
Move LazyTest into Control package

### DIFF
--- a/src/test/java/org/fungover/breeze/control/LazyTest.java
+++ b/src/test/java/org/fungover/breeze/control/LazyTest.java
@@ -1,6 +1,5 @@
-package org.fungover.breeze;
+package org.fungover.breeze.control;
 
-import org.fungover.breeze.control.Lazy;
 import org.fungover.breeze.funclib.control.Try;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This pull request was created because of a mistake made in the LazyT branch where the LazyTest class is floating around outside of the control package where it belongs. So the change here is a transportation of the test class from outside the control package to inside the control package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release includes minor internal improvements to our testing framework that enhance code organization and maintainability. There are no visible changes to application functionality.

- **Tests**
	- Streamlined test code organization for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->