### PR TITLE
Implement Text to ASCII Art Generator with Standard and Block Fonts

### DIFF
--- a/src/main/java/org/fungover/breeze/ascii2/AsciiArtGenerator.java
+++ b/src/main/java/org/fungover/breeze/ascii2/AsciiArtGenerator.java
@@ -1,0 +1,16 @@
+package org.fungover.breeze.ascii2;
+
+public class AsciiArtGenerator {
+
+    private final AsciiFont font;
+
+    public AsciiArtGenerator(AsciiFont font) {
+        this.font = font;
+    }
+
+    public String generate(String text) {
+        if (text == null || text.isBlank()) throw new IllegalArgumentException("Text cannot be null or empty");
+        if (text.length() > 50) throw new IllegalArgumentException("Text too long. Max 50 characters.");
+        return font.render(text);
+    }
+}

--- a/src/main/java/org/fungover/breeze/ascii2/AsciiFont.java
+++ b/src/main/java/org/fungover/breeze/ascii2/AsciiFont.java
@@ -1,0 +1,6 @@
+package org.fungover.breeze.ascii2;
+
+public interface AsciiFont {
+    String render(String text);
+    String getName();
+}

--- a/src/main/java/org/fungover/breeze/ascii2/BlockFont.java
+++ b/src/main/java/org/fungover/breeze/ascii2/BlockFont.java
@@ -1,0 +1,59 @@
+package org.fungover.breeze.ascii2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BlockFont implements AsciiFont {
+
+    private final Map<Character, String[]> fontMap = new HashMap<>();
+
+    public BlockFont() {
+        loadFont();
+    }
+
+    private void loadFont() {
+        fontMap.put('H', new String[]{
+                "██  ██",
+                "██████",
+                "██  ██"
+        });
+        fontMap.put('E', new String[]{
+                "█████ ",
+                "████  ",
+                "█████ "
+        });
+        fontMap.put('L', new String[]{
+                "██    ",
+                "██    ",
+                "█████ "
+        });
+        fontMap.put('O', new String[]{
+                " ███  ",
+                "█   █ ",
+                " ███  "
+        });
+    }
+
+    @Override
+    public String render(String text) {
+        if (text == null || text.isBlank()) throw new IllegalArgumentException("Text cannot be null or empty");
+        text = text.toUpperCase();
+        StringBuilder sb = new StringBuilder();
+        int height = 3;
+        for (int row = 0; row < height; row++) {
+            for (char c : text.toCharArray()) {
+                if (!fontMap.containsKey(c)) {
+                    throw new IllegalArgumentException("Unsupported character: " + c);
+                }
+                sb.append(fontMap.get(c)[row]).append("  ");
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getName() {
+        return "Block";
+    }
+}

--- a/src/main/java/org/fungover/breeze/ascii2/StandardFont.java
+++ b/src/main/java/org/fungover/breeze/ascii2/StandardFont.java
@@ -1,0 +1,70 @@
+package org.fungover.breeze.ascii2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StandardFont implements AsciiFont {
+
+    private final Map<Character, String[]> fontMap = new HashMap<>();
+
+    public StandardFont() {
+        loadFont();
+    }
+
+    private void loadFont() {
+        // Förenklad version, fler kan läggas till
+        fontMap.put('A', new String[]{
+                "  A  ",
+                " A A ",
+                "AAAAA"
+        });
+        fontMap.put('B', new String[]{
+                "BBB ",
+                "B  B",
+                "BBB "
+        });
+        fontMap.put('H', new String[]{
+                "H  H",
+                "HHHH",
+                "H  H"
+        });
+        fontMap.put('E', new String[]{
+                "EEE ",
+                "EE  ",
+                "EEE "
+        });
+        fontMap.put('L', new String[]{
+                "L   ",
+                "L   ",
+                "LLL "
+        });
+        fontMap.put('O', new String[]{
+                " OO ",
+                "O  O",
+                " OO "
+        });
+    }
+
+    @Override
+    public String render(String text) {
+        if (text == null || text.isBlank()) throw new IllegalArgumentException("Text cannot be null or empty");
+        text = text.toUpperCase();
+        StringBuilder sb = new StringBuilder();
+        int height = 3;
+        for (int row = 0; row < height; row++) {
+            for (char c : text.toCharArray()) {
+                if (!fontMap.containsKey(c)) {
+                    throw new IllegalArgumentException("Unsupported character: " + c);
+                }
+                sb.append(fontMap.get(c)[row]).append("  ");
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getName() {
+        return "Standard";
+    }
+}

--- a/src/test/java/org/fungover/breeze/ascii2/AsciiArtGeneratorTest.java
+++ b/src/test/java/org/fungover/breeze/ascii2/AsciiArtGeneratorTest.java
@@ -1,0 +1,40 @@
+package org.fungover.breeze.ascii2;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsciiArtGeneratorTest {
+
+    @Test
+    void testStandardFontHello() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new StandardFont());
+        String output = gen.generate("HELLO");
+        assertTrue(output.contains("H  H"));
+    }
+
+    @Test
+    void testBlockFontHello() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new BlockFont());
+        String output = gen.generate("HELLO");
+        assertTrue(output.contains("██  ██"));
+    }
+
+    @Test
+    void testNullInputThrowsException() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new StandardFont());
+        assertThrows(IllegalArgumentException.class, () -> gen.generate(null));
+    }
+
+    @Test
+    void testEmptyInputThrowsException() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new StandardFont());
+        assertThrows(IllegalArgumentException.class, () -> gen.generate(""));
+    }
+
+    @Test
+    void testTooLongInputThrowsException() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new StandardFont());
+        String longText = "A".repeat(60);
+        assertThrows(IllegalArgumentException.class, () -> gen.generate(longText));
+    }
+}


### PR DESCRIPTION
This PR implements a utility for converting plain text into ASCII art. 
Supports Standard and Block font styles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added text-to-ASCII art rendering with selectable font styles (Standard and Block).
  - Provides clear validation errors for empty or null input, overly long text (50+ characters), and unsupported characters.
- Tests
  - Introduced comprehensive tests covering successful rendering and validation scenarios (null, empty, excessive length).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->