### PR TITLE
Implement Text to ASCII Art Generator with Standard and Block Fonts (#139)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,6 @@
             <artifactId>assertj-core</artifactId>
             <version>3.27.3</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
             <artifactId>assertj-core</artifactId>
             <version>3.27.3</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/org/fungover/breeze/ascii2/AsciiArtGenerator.java
+++ b/src/main/java/org/fungover/breeze/ascii2/AsciiArtGenerator.java
@@ -1,0 +1,16 @@
+package org.fungover.breeze.ascii2;
+
+public class AsciiArtGenerator {
+
+    private final AsciiFont font;
+
+    public AsciiArtGenerator(AsciiFont font) {
+        this.font = font;
+    }
+
+    public String generate(String text) {
+        if (text == null || text.isBlank()) throw new IllegalArgumentException("Text cannot be null or empty");
+        if (text.length() > 50) throw new IllegalArgumentException("Text too long. Max 50 characters.");
+        return font.render(text);
+    }
+}

--- a/src/main/java/org/fungover/breeze/ascii2/AsciiFont.java
+++ b/src/main/java/org/fungover/breeze/ascii2/AsciiFont.java
@@ -1,0 +1,7 @@
+package org.fungover.breeze.ascii2;
+
+public interface AsciiFont {
+
+    String render(String text);
+    String getName();
+}

--- a/src/main/java/org/fungover/breeze/ascii2/BlockFont.java
+++ b/src/main/java/org/fungover/breeze/ascii2/BlockFont.java
@@ -1,0 +1,59 @@
+package org.fungover.breeze.ascii2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BlockFont implements AsciiFont {
+
+    private final Map<Character, String[]> fontMap = new HashMap<>();
+
+    public BlockFont() {
+        loadFont();
+    }
+
+    private void loadFont() {
+        fontMap.put('H', new String[]{
+                "██  ██",
+                "██████",
+                "██  ██"
+        });
+        fontMap.put('E', new String[]{
+                "█████ ",
+                "████  ",
+                "█████ "
+        });
+        fontMap.put('L', new String[]{
+                "██    ",
+                "██    ",
+                "█████ "
+        });
+        fontMap.put('O', new String[]{
+                " ███  ",
+                "█   █ ",
+                " ███  "
+        });
+    }
+
+    @Override
+    public String render(String text) {
+        if (text == null || text.isBlank()) throw new IllegalArgumentException("Text cannot be null or empty");
+        text = text.toUpperCase();
+        StringBuilder sb = new StringBuilder();
+        int height = 3;
+        for (int row = 0; row < height; row++) {
+            for (char c : text.toCharArray()) {
+                if (!fontMap.containsKey(c)) {
+                    throw new IllegalArgumentException("Unsupported character: " + c);
+                }
+                sb.append(fontMap.get(c)[row]).append("  ");
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getName() {
+        return "Block";
+    }
+}

--- a/src/main/java/org/fungover/breeze/ascii2/StandardFont.java
+++ b/src/main/java/org/fungover/breeze/ascii2/StandardFont.java
@@ -1,0 +1,70 @@
+package org.fungover.breeze.ascii2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StandardFont implements AsciiFont {
+
+    private final Map<Character, String[]> fontMap = new HashMap<>();
+
+    public StandardFont() {
+        loadFont();
+    }
+
+    private void loadFont() {
+        // Förenklad version, fler kan läggas till
+        fontMap.put('A', new String[]{
+                "  A  ",
+                " A A ",
+                "AAAAA"
+        });
+        fontMap.put('B', new String[]{
+                "BBB ",
+                "B  B",
+                "BBB "
+        });
+        fontMap.put('H', new String[]{
+                "H  H",
+                "HHHH",
+                "H  H"
+        });
+        fontMap.put('E', new String[]{
+                "EEE ",
+                "EE  ",
+                "EEE "
+        });
+        fontMap.put('L', new String[]{
+                "L   ",
+                "L   ",
+                "LLL "
+        });
+        fontMap.put('O', new String[]{
+                " OO ",
+                "O  O",
+                " OO "
+        });
+    }
+
+    @Override
+    public String render(String text) {
+        if (text == null || text.isBlank()) throw new IllegalArgumentException("Text cannot be null or empty");
+        text = text.toUpperCase();
+        StringBuilder sb = new StringBuilder();
+        int height = 3;
+        for (int row = 0; row < height; row++) {
+            for (char c : text.toCharArray()) {
+                if (!fontMap.containsKey(c)) {
+                    throw new IllegalArgumentException("Unsupported character: " + c);
+                }
+                sb.append(fontMap.get(c)[row]).append("  ");
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getName() {
+        return "Standard";
+    }
+}

--- a/src/main/java/org/fungover/breeze/ascii2/StandardFont.java
+++ b/src/main/java/org/fungover/breeze/ascii2/StandardFont.java
@@ -12,7 +12,7 @@ public class StandardFont implements AsciiFont {
     }
 
     private void loadFont() {
-        // Förenklad version, fler kan läggas till
+        // Simplified version, more characters can be added
         fontMap.put('A', new String[]{
                 "  A  ",
                 " A A ",

--- a/src/test/java/org/fungover/breeze/ascii2/AsciiArtGeneratorTest.java
+++ b/src/test/java/org/fungover/breeze/ascii2/AsciiArtGeneratorTest.java
@@ -1,0 +1,40 @@
+package org.fungover.breeze.ascii2;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsciiArtGeneratorTest {
+
+    @Test
+    void testStandardFontHello() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new StandardFont());
+        String output = gen.generate("HELLO");
+        assertTrue(output.contains("H  H"));
+    }
+
+    @Test
+    void testBlockFontHello() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new BlockFont());
+        String output = gen.generate("HELLO");
+        assertTrue(output.contains("██  ██"));
+    }
+
+    @Test
+    void testNullInputThrowsException() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new StandardFont());
+        assertThrows(IllegalArgumentException.class, () -> gen.generate(null));
+    }
+
+    @Test
+    void testEmptyInputThrowsException() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new StandardFont());
+        assertThrows(IllegalArgumentException.class, () -> gen.generate(""));
+    }
+
+    @Test
+    void testTooLongInputThrowsException() {
+        AsciiArtGenerator gen = new AsciiArtGenerator(new StandardFont());
+        String longText = "A".repeat(60);
+        assertThrows(IllegalArgumentException.class, () -> gen.generate(longText));
+    }
+}


### PR DESCRIPTION
Summary This pull request implements a Text to ASCII Art Generator that supports two font styles: Standard and Block.

 Changes 
 
 Added AsciiArtGenerator class to handle text generation with validation (null, empty, max length 50). 
 
 Added AsciiFont interface for font abstraction. 
 
 Implemented StandardFont and BlockFont classes with simple ASCII mappings. 
 
 Added unit tests in AsciiArtGeneratorTest to verify:
 
  Text rendering for both fonts
   Exception handling for invalid inputs 
   
   Testing All tests pass using JUnit 5. 
   
   Verified correct ASCII output for "HELLO" in both fonts. 
   
   Related Issue 
   Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate ASCII art from text with selectable font styles (Standard and Block).
  * Supports multi-line output for clear, stylized rendering.
* **Improvements**
  * Input validation with helpful errors for null/blank text and unsupported characters.
  * Text length limited to 50 characters to ensure reliable output.
* **Tests**
  * Added coverage for font rendering of sample text and validation scenarios (null, empty, and overly long input).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->